### PR TITLE
feat: darkmodebutton component persists dark/light mode with local storage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -457,6 +457,11 @@
         }
       }
     },
+    "@vue/devtools-api": {
+      "version": "6.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.0.0-beta.2.tgz",
+      "integrity": "sha512-5k0A8ffjNNukOiceImBdx1e3W5Jbpwqsu7xYHiZVu9mn4rYxFztIt+Q25mOHm7nwvDnMHrE7u5KtY2zmd+81GA=="
+    },
     "@vue/reactivity": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.0.0.tgz",
@@ -2676,6 +2681,14 @@
           "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.0.0.tgz",
           "integrity": "sha512-4XWL/avABGxU2E2ZF1eZq3Tj7fvksCMssDZUHOykBIMmh5d+KcAnQMC5XHMhtnA0NAvktYsA2YpdsVwVmhWzvA=="
         }
+      }
+    },
+    "vue-composable": {
+      "version": "1.0.0-beta.10",
+      "resolved": "https://registry.npmjs.org/vue-composable/-/vue-composable-1.0.0-beta.10.tgz",
+      "integrity": "sha512-5EuOxadlspBMZeRxPcaB0oo4PNRUpIk9mVBH14tv0+ES2gOmTwsGZin7aP/1lye2WmCrdu/OAA14t3UHJHfdWw==",
+      "requires": {
+        "@vue/devtools-api": "^6.0.0-beta.2"
       }
     },
     "wcwidth": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "dependencies": {
     "lodash-es": "4.17.15",
-    "vue": "^v3.0.0"
+    "vue": "^v3.0.0",
+    "vue-composable": "^1.0.0-beta.10"
   },
   "devDependencies": {
     "vite": "^v1.0.0-rc.4",

--- a/src/components/LayoutEditor.vue
+++ b/src/components/LayoutEditor.vue
@@ -17,8 +17,8 @@ export { default as SidebarRight } from './basic/SidebarRight.vue'
 export { default as PropsSidebar } from './props/PropsSidebar.vue'
 export { default as LiveCode } from './code/LiveCode.vue'
 
-import { watch, ref, computed } from 'vue'
-export { darkmode, mainArea, currentArea } from '../store.js'
+import { ref, computed } from 'vue'
+export { mainArea, currentArea } from '../store.js'
 
 export default {
   props: {
@@ -28,10 +28,6 @@ export default {
 
 export let activeSidebar = ref(true)
 export let activeSidebarRight = ref(true)
-
-watch(darkmode, () => {
-  document.getElementById('app').classList[darkmode.value ? 'add' : 'remove']('darkmode')
-})
 </script>
 
 <style lang="scss">
@@ -88,7 +84,7 @@ p {
   background: linear-gradient(#1d032d, #300748);
   height: 100%;
   display: grid;
-  grid-template-columns: 220px 1fr 400px;  
+  grid-template-columns: 220px 1fr 400px;
   grid-column-gap: 15px;
   @media screen and (max-width: 768px) {
     display: block;

--- a/src/components/props/DarkModeButton.vue
+++ b/src/components/props/DarkModeButton.vue
@@ -1,0 +1,52 @@
+<template>
+  <button aria-label="Toggle dark mode" :class="['btn-dark', { active: darkmode }]" @click="darkmode = !darkmode">
+    <IconDark />
+  </button>
+</template>
+
+<script setup>
+import { onMounted, watch } from 'vue'
+import { useLocalStorage } from 'vue-composable'
+export { default as IconDark } from '../icons/IconDark.vue'
+export { darkmode } from '../../store'
+
+const { storage: darkmodeStorage } = useLocalStorage('dark-mode', null)
+
+onMounted(() => {
+  if (darkmodeStorage.value !== null) {
+    return (darkmode.value = darkmodeStorage.value)
+  }
+  const darkModeMediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+  if (darkModeMediaQuery.media !== 'not all') {
+    darkmode.value = darkModeMediaQuery.matches
+  }
+})
+
+watch(darkmode, () => {
+  darkmodeStorage.value = darkmode.value
+  document.getElementById('app').classList[darkmode.value ? 'add' : 'remove']('darkmode')
+})
+</script>
+
+<style scoped lang="scss">
+button.btn-dark {
+  margin-bottom: 10px;
+  background: var(--color-darkmode);
+  color: #fff;
+  border: 0;
+  border-radius: 25px;
+  cursor: pointer;
+  height: 35px;
+  width: 35px;
+  padding: 10px;
+  &.active {
+    background: var(--color-darkmode-active);
+  }
+}
+
+.btn-dark {
+  position: fixed;
+  bottom: 5px;
+  left: 15px;
+}
+</style>

--- a/src/components/props/DarkModeButton.vue
+++ b/src/components/props/DarkModeButton.vue
@@ -1,5 +1,10 @@
 <template>
-  <button aria-label="Toggle dark mode" :class="['btn-dark', { active: darkmode }]" @click="darkmode = !darkmode">
+  <button
+    aria-label="Toggle dark mode"
+    :class="['btn-dark', { active: darkmode }]"
+    @click.left="toggleDarkmode"
+    @click.prevent.right="switchToSystemTheme"
+  >
     <IconDark />
   </button>
 </template>
@@ -10,22 +15,30 @@ import { useLocalStorage } from 'vue-composable'
 export { default as IconDark } from '../icons/IconDark.vue'
 export { darkmode } from '../../store'
 
-const { storage: darkmodeStorage } = useLocalStorage('dark-mode', null)
+const { storage: themeStorage } = useLocalStorage('theme', null)
+
+export function toggleDarkmode() {
+  darkmode.value = !darkmode.value
+  themeStorage.value = darkmode.value ? 'dark' : 'light'
+}
+
+export function switchToSystemTheme() {
+  darkmode.value = getSystemTheme() === 'dark'
+  themeStorage.value = null
+}
 
 onMounted(() => {
-  if (darkmodeStorage.value !== null) {
-    return (darkmode.value = darkmodeStorage.value)
-  }
-  const darkModeMediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
-  if (darkModeMediaQuery.media !== 'not all') {
-    darkmode.value = darkModeMediaQuery.matches
-  }
+  darkmode.value = (themeStorage.value || getSystemTheme()) === 'dark'
 })
 
 watch(darkmode, () => {
-  darkmodeStorage.value = darkmode.value
   document.getElementById('app').classList[darkmode.value ? 'add' : 'remove']('darkmode')
 })
+
+function getSystemTheme() {
+  const darkModeMediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+  return darkModeMediaQuery.media !== 'not all' && darkModeMediaQuery.matches ? 'dark' : 'light'
+}
 </script>
 
 <style scoped lang="scss">

--- a/src/components/props/PropsSidebar.vue
+++ b/src/components/props/PropsSidebar.vue
@@ -9,9 +9,7 @@
 
     <HireUs />
     <VersionLabel />
-    <button aria-label="Toggle dark mode" :class="['btn-dark', { active: darkmode }]" @click="darkmode = !darkmode">
-      <IconDark />
-    </button>
+    <DarkModeButton />
     <button :disabled="!canUndo" aria-label="Undo" :class="['btn-undo']" @click="undo">Undo</button>
     <button :disabled="!canRedo" aria-label="Redo" :class="['btn-redo']" @click="redo">Redo</button>
   </div>
@@ -24,9 +22,10 @@ export { default as HireUs } from './HireUs.vue'
 export { default as IconDark } from '../icons/IconDark.vue'
 export { default as FlexOptions } from './FlexOptions.vue'
 export { default as GridOptions } from './GridOptions.vue'
+export { default as DarkModeButton } from './DarkModeButton.vue'
 
 import { computed } from 'vue'
-export { currentArea, darkmode, undo, redo, canUndo, canRedo } from '../../store.js'
+export { currentArea, undo, redo, canUndo, canRedo } from '../../store.js'
 
 export default {
   props: {
@@ -88,21 +87,6 @@ export const currentFlex = computed(() => currentArea.value.flex)
       transform: translateX(0);
     }
   }
-
-  button.btn-dark {
-    margin-bottom: 10px;
-    background: var(--color-darkmode);
-    color: #fff;
-    border: 0;
-    border-radius: 25px;
-    cursor: pointer;
-    height: 35px;
-    width: 35px;
-    padding: 10px;
-    &.active {
-      background: var(--color-darkmode-active);
-    }
-  }
 }
 
 .hire-us {
@@ -115,12 +99,6 @@ export const currentFlex = computed(() => currentArea.value.flex)
   position: fixed;
   bottom: 15px;
   left: 130px;
-}
-
-.btn-dark {
-  position: fixed;
-  bottom: 5px;
-  left: 15px;
 }
 
 .btn-undo,


### PR DESCRIPTION
- Created a separate file for DarkModeButton, so logic can be handled there.
- Persists the last user theme choice using local storage.
- Added check for prefers-color-scheme if there is no dark mode key on local storage.
@matias-capeletto @agustin-capeletto-lenio  