### PR TITLE
Resolved issue where grid lines overflow main grid container while dragging

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,20 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="Description" content="Layoutit Grid. CSS Grid Generator." />
     <title>Layoutit Grid</title>
+    <meta name="title" content="Layoutit Grid — CSS Grids layouts made easy!">
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://metatags.io/">
+    <meta property="og:title" content="Layoutit Grid — CSS Grids layouts made easy!">
+    <meta property="og:description" content="Layoutit grid is a CSS Grid layout generator. Quickly draw down web pages layouts with our clean editor, and get HTML and CSS code to quickstart your next project.">
+    <meta property="og:image" content="https://raw.githubusercontent.com/Leniolabs/layoutit-grid/main/assets/layoutit-grid-showcase.gif">
+
+    <!-- Twitter -->
+    <meta property="twitter:card" content="summary_large_image">
+    <meta property="twitter:url" content="https://metatags.io/">
+    <meta property="twitter:title" content="Layoutit Grid — CSS Grids layouts made easy!">
+    <meta property="twitter:description" content="Layoutit grid is a CSS Grid layout generator. Quickly draw down web pages layouts with our clean editor, and get HTML and CSS code to quickstart your next project.">
+    <meta property="twitter:image" content="https://raw.githubusercontent.com/Leniolabs/layoutit-grid/main/assets/layoutit-grid-showcase.gif">
   </head>
   <body>
     <div id="app"></div>

--- a/src/components/grid/GridCell.vue
+++ b/src/components/grid/GridCell.vue
@@ -104,13 +104,9 @@ export const isDraggingSection = computed(
     (dragging.value.colLine === props.section.col.start || dragging.value.rowLine === props.section.row.start)
 )
 
-export const isDraggingCol = computed(
-  () => isDraggingGrid.value && dragging.value.colLine === props.section.col.start && props.section.row.start === 1
-)
+export const isDraggingCol = computed(() => isDraggingGrid.value && dragging.value.colLine === props.section.col.start)
 
-export const isDraggingRow = computed(
-  () => isDraggingGrid.value && dragging.value.rowLine === props.section.row.start && props.section.col.start === 1
-)
+export const isDraggingRow = computed(() => isDraggingGrid.value && dragging.value.rowLine === props.section.row.start)
 
 export function showInsideColSize(col) {
   return isDraggingGrid.value && (col === dragging.value.colLine - 1 || col === dragging.value.colLine - 2)
@@ -229,6 +225,7 @@ section {
     //z-index: 9;
     top: 0;
     cursor: col-resize;
+    overflow: hidden;
     &.dragging:after {
       content: '';
       width: 1px;
@@ -250,6 +247,7 @@ section {
     top: -10px;
     cursor: row-resize;
     //z-index: 9;
+    overflow: hidden;
     &.dragging:after {
       content: '';
       height: 1px;


### PR DESCRIPTION
The original code had a check for isDraggingCol and isDraggingRow that wouldn't correctly add 'dragging' class to all sections affected by the drag.  Resolves #44

Also added Social Media meta tags. Resolves #26 