### PR TITLE
add theme color meta tag for PWA

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
     <link rel="apple-touch-icon" href="/img/icons/icon-128x128.png" type="image/png" sizes="128x128">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="Description" content="Quickly design web layouts, and get HTML and CSS code. Learn CSS Grid visually and build web layouts with our interactive CSS Grid Generator." />
+    <meta name="theme-color" content="#1D032D" />
     <title>Interactive CSS Grid Generator | Layoutit Grid</title>
     <meta name="title" content="Interactive CSS Grid Generator | Layoutit Grid">
     <!-- Open Graph / Facebook -->


### PR DESCRIPTION
Adding tag required by google lighthouse report.

Color hex matches brand colors.