### PR TITLE
fix(pwa): update pwa config and some small updates on `index.html`

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" href="/favicon.ico" />
     <link rel="shortcut icon" href="/favicon.ico">
     <link rel="apple-touch-icon" href="/img/icons/icon-128x128.png" type="image/png" sizes="128x128">
-    <link rel="mask-icon" href="/img/icons//safari-pinned-tab.svg" color="#1D032D">
+    <link rel="mask-icon" href="/img/icons/safari-pinned-tab.svg" color="#1D032D">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="Description" content="Quickly design web layouts, and get HTML and CSS code. Learn CSS Grid visually and build web layouts with our interactive CSS Grid Generator." />
     <meta name="theme-color" content="#1D032D" />
@@ -25,6 +25,7 @@
     <meta property="twitter:description" content="Quickly design web layouts, and get HTML and CSS code. Learn CSS Grid visually build web layouts with our interactive CSS Grid Generator.">
     <meta property="twitter:image" content="https://raw.githubusercontent.com/Leniolabs/layoutit-grid/main/assets/layoutit-grid-showcase-v2.gif">
     <link rel="prefetch" href="/img/icons/icon-44x44.png" />
+    <link rel="prefetch" href="/manifest.webmanifest" />
   </head>
   <body>
     <div id="app"></div>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -89,6 +89,8 @@ export default defineConfig({
     viteComponentsPlugin(),
     LayouitPlugin(),
     VitePWA({
+      base: '/',
+      scope: '/',
       registerType: 'autoUpdate',
       includeAssets: [
         'favicon.ico',
@@ -102,13 +104,11 @@ export default defineConfig({
         // short_name: 'CSS Grid Generator',
         short_name: 'LayoutIt Grid',
         description: 'Layoutit Grid is an interactive open source CSS Grid generator.',
-        start_url: '/',
         display: 'standalone',
         orientation: 'portrait-primary',
         background_color: '#1D032D',
         lang: 'en',
         theme_color: '#1D032D',
-        scope: '/',
         categories: ['education', 'personalization', 'productivity', 'utilities'],
         screenshots: [
           {


### PR DESCRIPTION
- move pwa manifest options to pwa plugin options
- remove double slash from `mask-icon` on `index.html`
- add `/manifest.webmanifest prefetch` on `index.html` to remove preload warning from lighthouse.