### PR TITLE
fix: grid-auto-flow unnecesary space removed

### DIFF
--- a/src/components/common/GridAutoFlowSelect.vue
+++ b/src/components/common/GridAutoFlowSelect.vue
@@ -73,7 +73,6 @@ const optionTooltipsFlow = {
     font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
     direction: ltr;
     text-align: left;
-    white-space: pre;
     word-spacing: normal;
     line-height: 30px;
     span {


### PR DESCRIPTION
**Layoutit - Implicit grid**

* Grid auto flow - unnecessary space removed

**Evidence:**

<img width="1440" alt="Screen Shot 2021-08-26 at 09 35 22" src="https://user-images.githubusercontent.com/52363523/130973651-ddaef3f3-dbbf-46b2-867f-b3743f6f0a46.png">
