### PR TITLE
fix: scrollbars after adding line names

### DIFF
--- a/src/components/grid/LineName.vue
+++ b/src/components/grid/LineName.vue
@@ -6,6 +6,7 @@
     :style="style"
     :class="[type, { first: pos === 1, last: pos === grid[type].lineNames.length }]"
     aria-label="line name"
+    maxlength="20"
     @input="line.name = $event.target.value"
     @keydown="onKeydown"
     @pointerdown.stop
@@ -105,7 +106,7 @@ defineExpose({ focus, toggle })
   &:not(.last) {
     border-bottom-right-radius: 6px;
   }
-  bottom: 0;
+  bottom: 1px;
   right: -2px;
   transform-origin: 0 12px;
   transform: translateX(100%) translateY(10px) rotate(-90deg);


### PR DESCRIPTION
**Layoutit - Linename**

- Max length added to the input in order to avoid too large names

- Bottom increased to 1px to avoid unnecessary vertical scroll

**Evidence**:

![Screen Shot 2021-08-28 at 17 49 18](https://user-images.githubusercontent.com/52363523/131233526-32ba919f-6d7b-4895-8713-9d3c94a1ff37.png)


<img width="1430" alt="Screen Shot 2021-08-28 at 20 38 23" src="https://user-images.githubusercontent.com/52363523/131233573-cac367e2-7ab4-4872-a467-88932a18fe18.png">



