### PR TITLE
fix: Add .npmrc file to enforce Node.js and pnpm versions

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+# .npmrc
+engine-strict=true

--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ Read more about [learning CSS Grid visually with a generator here](https://css-t
 
 These instructions will get you a copy of the project up and running on your local machine for development
 
+### Prerequisites
+Ensure you have the following versions installed on your local machine:
+
+Node.js: >= 14.0.0 < 17.0.0
+pnpm: 6.x.x
+
 ### Clone the repo
 
 Use ssh

--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
     "test:open": "cypress open",
     "test": "cypress run"
   },
+  "engines": {
+    "node": ">=14.0.0 <17.0.0",
+    "pnpm": "6.x.x"
+  },
   "dependencies": {
     "@stackblitz/sdk": "^1.5.3",
     "@vueuse/core": "^6.0.0",


### PR DESCRIPTION
#### Summary

This pull request adds a `.npmrc` file to enforce the Node.js and pnpm versions specified in the `package.json` file. This change ensures that developers and CI environments use the correct versions, improving consistency and preventing potential issues caused by version mismatches.

#### Changes

- Added an `engines` field to the `package.json` to specify Node.js and pnpm versions.
- Created a `.npmrc` file with `engine-strict=true` to enforce these versions.
- Updated README.md of prerequisites

#### Related Issue

This PR addresses issue https://github.com/Leniolabs/layoutit-grid/issues/115.
