### PR TITLE
fix: replace deprecated dedupe with resolve.dedupe

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -87,7 +87,9 @@ const LayouitPlugin = (): Plugin => {
 }
 
 export default defineConfig({
-  dedupe: ['vue'],
+  resolve: {
+    dedupe: ['vue']
+  },
   plugins: [
     vuePlugin({
       refTransform: true,


### PR DESCRIPTION
I've just noticed below warning during compilation
(!) "dedupe" option is deprecated. Use "resolve.dedupe" instead.